### PR TITLE
Add --allow-dirty flag to get publishing to crates.io working

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,3 +70,5 @@ jobs:
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
       with:
           registry-token: ${{ secrets.CRATES_API_TOKEN }}
+          args: '--allow-dirty'
+          dry-run: true


### PR DESCRIPTION
Required because there is some messing around with the Cargo.* files to set the version dynamically.